### PR TITLE
Atualização da estrutura da aplicação frontend

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Next: Node",
+      "runtimeExecutable": "${workspaceRoot}/frontend/node_modules/next/dist/bin/next",
+      "runtimeArgs": ["--inspect"],
+      "port": 9229,
+      "console": "integratedTerminal",
+      "cwd": "${workspaceRoot}/frontend/src"
+    }
+  ]
+}

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
     ],
 
     'react/jsx-indent': 'off', // Incompatible with prettier
+    'react/destructuring-assignment': 'off', // airbnb use error
     // 'react/jsx-closing-bracket-location': 'off', // Incompatible with prettier
     // 'react/jsx-wrap-multilines': 'off', // Incompatible with prettier
     // 'react/jsx-indent-props': 'off', // Incompatible with prettier

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7825,9 +7825,9 @@
       }
     },
     "react-apollo": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.2.4.tgz",
-      "integrity": "sha512-haS5R30Qvteb65ZLfWomUZQh47VU4ld4Kof3zlqdbLOrYPt3/DdVZC8ZFPZSxd5zPeIJtZqpUfAxD1WHVoMPIA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.3.1.tgz",
+      "integrity": "sha512-xPteQmCzMJT8wE4v0zq38E6JWLhrNcJENl66fP117lwzU2lZA+qoUDcizqKl0z2OY5b+KklmqnPPD+wcWAdy7w==",
       "requires": {
         "fbjs": "^1.0.0",
         "hoist-non-react-statics": "^3.0.0",
@@ -7853,17 +7853,17 @@
           }
         },
         "hoist-non-react-statics": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz",
-          "integrity": "sha512-1kXwPsOi0OGQIZNVMPvgWJ9tSnGMiMfJdihqEzrPEXlHOBh9AAHXX/QYmAJTXztnz/K+PQ8ryCb4eGaN6HlGbQ==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz",
+          "integrity": "sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==",
           "requires": {
             "react-is": "^16.3.2"
           }
         },
         "ua-parser-js": {
-          "version": "0.7.18",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-          "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+          "version": "0.7.19",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+          "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
         }
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "nprogress": "^0.2.0",
     "prop-types": "^15.6.2",
     "react": "^16.6.0",
-    "react-apollo": "^2.2.4",
+    "react-apollo": "^2.3.1",
     "react-dom": "^16.6.0",
     "react-filepond": "^5.0.0",
     "react-jss": "^8.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,6 @@
     "apollo-link-http": "^1.5.5",
     "classnames": "^2.2.6",
     "cookie": "^0.3.1",
-    "cross-env": "^5.2.0",
     "filepond": "^3.3.0",
     "filepond-plugin-image-exif-orientation": "^1.0.3",
     "filepond-plugin-image-preview": "^3.1.3",
@@ -48,6 +47,7 @@
   "devDependencies": {
     "@types/next": "^7.0.4",
     "babel-eslint": "^10.0.1",
+    "cross-env": "^5.2.0",
     "eslint": "^5.7.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^3.1.0",

--- a/frontend/src/components/AppDrawer.js
+++ b/frontend/src/components/AppDrawer.js
@@ -5,6 +5,7 @@ import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import Toolbar from '@material-ui/core/Toolbar';
 import Drawer from '@material-ui/core/Drawer';
+import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 import Typography from '@material-ui/core/Typography';
 import Divider from '@material-ui/core/Divider';
 import Hidden from '@material-ui/core/Hidden';
@@ -43,18 +44,18 @@ function renderNavItems({ pages, ...params }) {
   return (
     <List>
       {pages.reduce(
-    // eslint-disable-next-line no-use-before-define
+        // eslint-disable-next-line no-use-before-define
         (items, page) => reduceChildRoutes({ items, page, ...params }),
         [],
       )}
     </List>
   );
-  }
+}
 
 function reduceChildRoutes({ props, activePage, items, page, depth }) {
   if (page.displayNav === false) {
     return items;
-}
+  }
 
   if (page.children && page.children.length > 1) {
     const title = pageToTitle(page);
@@ -83,8 +84,13 @@ function reduceChildRoutes({ props, activePage, items, page, depth }) {
   return items;
 }
 
+// iOS is hosted on high-end devices. We can enable the backdrop transition without
+// dropping frames. The performance will be good enough.
+// So: <SwipeableDrawer disableBackdropTransition={false} />
+const iOS = process.browser && /iPad|iPhone|iPod/.test(navigator.userAgent);
+
 function AppDrawer(props, context) {
-  const { classes, className, disablePermanent, mobileOpen, onClose } = props;
+  const { classes, className, disablePermanent, mobileOpen, onClose, onOpen } = props;
   const { pages, activePage } = context;
 
   const drawer = (
@@ -104,21 +110,23 @@ function AppDrawer(props, context) {
   );
 
   return (
-    <div className={className}>
-      <Hidden lgUp={!disablePermanent}>
-        <Drawer
+    <nav className={className}>
+      <Hidden lgUp={!disablePermanent} implementation="js">
+        <SwipeableDrawer
           classes={{
             paper: classNames(classes.paper, 'algolia-drawer'),
           }}
+          disableBackdropTransition={!iOS}
           variant="temporary"
           open={mobileOpen}
+          onOpen={onOpen}
           onClose={onClose}
           ModalProps={{
             keepMounted: true,
           }}
         >
           {drawer}
-        </Drawer>
+        </SwipeableDrawer>
       </Hidden>
       {disablePermanent ? null : (
         <Hidden mdDown implementation="css">
@@ -133,7 +141,7 @@ function AppDrawer(props, context) {
           </Drawer>
         </Hidden>
       )}
-    </div>
+    </nav>
   );
 }
 
@@ -143,6 +151,7 @@ AppDrawer.propTypes = {
   disablePermanent: PropTypes.bool.isRequired,
   mobileOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
+  onOpen: PropTypes.func.isRequired,
 };
 
 AppDrawer.contextTypes = {

--- a/frontend/src/components/AppDrawer.js
+++ b/frontend/src/components/AppDrawer.js
@@ -38,40 +38,43 @@ const styles = theme => ({
   },
 });
 
-function renderNavItems(props, pages, activePage) {
-  let navItems = null;
-
-  if (pages && pages.length) {
+// eslint-disable-next-line react/prop-types
+function renderNavItems({ pages, ...params }) {
+  return (
+    <List>
+      {pages.reduce(
     // eslint-disable-next-line no-use-before-define
-    navItems = pages.reduce(reduceChildRoutes.bind(null, props, activePage), []);
+        (items, page) => reduceChildRoutes({ items, page, ...params }),
+        [],
+      )}
+    </List>
+  );
   }
 
-  return <List>{navItems}</List>;
+function reduceChildRoutes({ props, activePage, items, page, depth }) {
+  if (page.displayNav === false) {
+    return items;
 }
 
-function reduceChildRoutes(props, activePage, items, childPage, index) {
-  if (childPage.children && childPage.children.length > 1) {
-    const openImmediately = activePage.pathname.indexOf(childPage.pathname) !== -1 || false;
+  if (page.children && page.children.length > 1) {
+    const title = pageToTitle(page);
+    const openImmediately = activePage.pathname.indexOf(`${page.pathname}/`) === 0;
 
-    /* eslint-disable function-paren-newline */
     items.push(
-      <AppDrawerNavItem
-        key={index}
-        openImmediately={openImmediately}
-        title={pageToTitle(childPage)}
-      >
-        {renderNavItems(props, childPage.children, activePage)}
+      <AppDrawerNavItem depth={depth} key={title} openImmediately={openImmediately} title={title}>
+        {renderNavItems({ props, pages: page.children, activePage, depth: depth + 1 })}
       </AppDrawerNavItem>,
     );
-  } else if (childPage.title !== false) {
-    childPage =
-      childPage.children && childPage.children.length === 1 ? childPage.children[0] : childPage;
+  } else {
+    const title = pageToTitle(page);
+    page = page.children && page.children.length === 1 ? page.children[0] : page;
 
     items.push(
       <AppDrawerNavItem
-        key={index}
-        title={pageToTitle(childPage)}
-        href={childPage.pathname}
+        depth={depth}
+        key={title}
+        title={title}
+        href={page.pathname}
         onClick={props.onClose}
       />,
     );
@@ -82,6 +85,7 @@ function reduceChildRoutes(props, activePage, items, childPage, index) {
 
 function AppDrawer(props, context) {
   const { classes, className, disablePermanent, mobileOpen, onClose } = props;
+  const { pages, activePage } = context;
 
   const drawer = (
     <div className={classes.nav}>
@@ -95,7 +99,7 @@ function AppDrawer(props, context) {
           <Divider absolute />
         </Toolbar>
       </div>
-      {renderNavItems(props, context.pages, context.activePage)}
+      {renderNavItems({ props, pages, activePage, depth: 0 })}
     </div>
   );
 

--- a/frontend/src/components/AppDrawer.js
+++ b/frontend/src/components/AppDrawer.js
@@ -12,6 +12,7 @@ import Hidden from '@material-ui/core/Hidden';
 import AppDrawerNavItem from './AppDrawerNavItem';
 import Link from './Link';
 import { pageToTitle } from '../utils/helpers';
+import PageContext from './PageContext';
 
 const styles = theme => ({
   paper: {
@@ -89,24 +90,27 @@ function reduceChildRoutes({ props, activePage, items, page, depth }) {
 // So: <SwipeableDrawer disableBackdropTransition={false} />
 const iOS = process.browser && /iPad|iPhone|iPod/.test(navigator.userAgent);
 
-function AppDrawer(props, context) {
+function AppDrawer(props) {
   const { classes, className, disablePermanent, mobileOpen, onClose, onOpen } = props;
-  const { pages, activePage } = context;
 
   const drawer = (
-    <div className={classes.nav}>
-      <div className={classes.toolbarIe11}>
-        <Toolbar className={classes.toolbar}>
-          <Link className={classes.title} href="/" onClick={onClose}>
-            <Typography variant="h3" color="inherit">
-              OliMAT
-            </Typography>
-          </Link>
-          <Divider absolute />
-        </Toolbar>
-      </div>
-      {renderNavItems({ props, pages, activePage, depth: 0 })}
-    </div>
+    <PageContext.Consumer>
+      {({ activePage, pages }) => (
+        <div className={classes.nav}>
+          <div className={classes.toolbarIe11}>
+            <Toolbar className={classes.toolbar}>
+              <Link className={classes.title} href="/" onClick={onClose}>
+                <Typography variant="h3" color="inherit">
+                  OliMAT
+                </Typography>
+              </Link>
+              <Divider absolute />
+            </Toolbar>
+          </div>
+          {renderNavItems({ props, pages, activePage, depth: 0 })}
+        </div>
+      )}
+    </PageContext.Consumer>
   );
 
   return (
@@ -152,11 +156,6 @@ AppDrawer.propTypes = {
   mobileOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onOpen: PropTypes.func.isRequired,
-};
-
-AppDrawer.contextTypes = {
-  activePage: PropTypes.object.isRequired,
-  pages: PropTypes.array.isRequired,
 };
 
 export default withStyles(styles)(AppDrawer);

--- a/frontend/src/components/AppDrawerNavItem.js
+++ b/frontend/src/components/AppDrawerNavItem.js
@@ -8,77 +8,87 @@ import Collapse from '@material-ui/core/Collapse';
 import Link from './Link';
 
 const styles = theme => ({
-  button: theme.mixins.gutters({
-    borderRadius: 0,
-    justifyContent: 'flex-start',
-    textTransform: 'none',
-    width: '100%',
-    transition: theme.transitions.create('background-color', {
-      duration: theme.transitions.duration.shortest,
-    }),
-    '&:hover': {
-      textDecoration: 'none',
-    },
-  }),
-  navItem: {
-    ...theme.typography.body2,
+  item: {
     display: 'block',
     paddingTop: 0,
     paddingBottom: 0,
   },
-  navLink: {
-    fontWeight: theme.typography.fontWeightRegular,
+  itemLeaf: {
     display: 'flex',
     paddingTop: 0,
     paddingBottom: 0,
   },
-  navLinkButton: {
-    color: theme.palette.text.secondary,
-    paddingLeft: theme.spacing.unit * 5,
-    fontSize: theme.typography.pxToRem(13),
+  button: {
+    letterSpacing: 0,
+    justifyContent: 'flex-start',
+    textTransform: 'none',
+    width: '100%',
   },
-  activeButton: {
-    color: theme.palette.text.primary,
+  buttonLeaf: {
+    letterSpacing: 0,
+    justifyContent: 'flex-start',
+    textTransform: 'none',
+    width: '100%',
+    fontWeight: theme.typography.fontWeightRegular,
+    '&.depth-0': {
+      fontWeight: theme.typography.fontWeightMedium,
+    },
+  },
+  active: {
+    color: theme.palette.primary.main,
+    fontWeight: theme.typography.fontWeightMedium,
   },
 });
 
 class AppDrawerNavItem extends React.Component {
-  static defaultProps = {
-    openImmediately: false,
-  };
-
   state = {
-    open: false,
+    open: this.props.openImmediately,
   };
 
-  componentWillMount() {
-    if (this.props.openImmediately) {
-      this.setState({ open: true });
+  componentDidMount() {
+    // So we only run this logic once.
+    if (!this.props.openImmediately) {
+      return;
+    }
+
+    // Center the selected item in the list container.
+    const activeElement = document.querySelector(`.${this.props.classes.active}`);
+    if (activeElement && activeElement.scrollIntoView) {
+      activeElement.scrollIntoView({});
     }
   }
 
   handleClick = () => {
-    this.setState({ open: !this.state.open });
+    this.setState(state => ({ open: !state.open }));
   };
 
   render() {
-    const { children, classes, href, openImmediately, title } = this.props;
+    const {
+      children,
+      classes,
+      depth,
+      href,
+      onClick,
+      openImmediately,
+      title,
+      ...other
+    } = this.props;
+
+    const style = {
+      paddingLeft: 8 * (3 + 2 * depth),
+    };
 
     if (href) {
       return (
-        <ListItem className={classes.navLink} disableGutters>
+        <ListItem className={classes.itemLeaf} disableGutters {...other}>
           <Button
             component={props => (
-              <Link
-                variant="button"
-                activeClassName={classes.activeButton}
-                href={href}
-                {...props}
-              />
+              <Link variant="button" activeClassName={classes.active} href={href} {...props} />
             )}
-            className={classNames(classes.button, classes.navLinkButton)}
+            className={classNames(classes.buttonLeaf, `depth-${depth}`)}
             disableRipple
-            onClick={this.props.onClick}
+            onClick={onClick}
+            style={style}
           >
             {title}
           </Button>
@@ -87,13 +97,14 @@ class AppDrawerNavItem extends React.Component {
     }
 
     return (
-      <ListItem className={classes.navItem} disableGutters>
+      <ListItem className={classes.item} disableGutters {...other}>
         <Button
           classes={{
             root: classes.button,
             label: openImmediately ? 'algolia-lvl0' : '',
           }}
           onClick={this.handleClick}
+          style={style}
         >
           {title}
         </Button>
@@ -108,10 +119,15 @@ class AppDrawerNavItem extends React.Component {
 AppDrawerNavItem.propTypes = {
   children: PropTypes.node,
   classes: PropTypes.object.isRequired,
+  depth: PropTypes.number.isRequired,
   href: PropTypes.string,
   onClick: PropTypes.func,
   openImmediately: PropTypes.bool,
   title: PropTypes.string.isRequired,
+};
+
+AppDrawerNavItem.defaultProps = {
+  openImmediately: false,
 };
 
 export default withStyles(styles)(AppDrawerNavItem);

--- a/frontend/src/components/AppFrame.js
+++ b/frontend/src/components/AppFrame.js
@@ -128,8 +128,12 @@ class AppFrame extends React.Component {
     mobileOpen: false,
   };
 
-  handleDrawerToggle = () => {
-    this.setState({ mobileOpen: !this.state.mobileOpen });
+  handleDrawerOpen = () => {
+    this.setState({ mobileOpen: true });
+  };
+
+  handleDrawerClose = () => {
+    this.setState({ mobileOpen: false });
   };
 
   render() {
@@ -162,7 +166,7 @@ class AppFrame extends React.Component {
             <IconButton
               color="inherit"
               aria-label="open drawer"
-              onClick={this.handleDrawerToggle}
+              onClick={this.handleDrawerOpen}
               className={navIconClassName}
             >
               <MenuIcon />
@@ -179,7 +183,8 @@ class AppFrame extends React.Component {
         <AppDrawer
           className={classes.drawer}
           disablePermanent={disablePermanent}
-          onClose={this.handleDrawerToggle}
+          onClose={this.handleDrawerClose}
+          onOpen={this.handleDrawerOpen}
           mobileOpen={this.state.mobileOpen}
         />
         {children}

--- a/frontend/src/components/AppFrame.js
+++ b/frontend/src/components/AppFrame.js
@@ -12,8 +12,8 @@ import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import AppDrawer from './AppDrawer';
-import { pageToTitle } from '../utils/helpers';
 import UserMenuAppBar from './UserMenuAppBar';
+import PageTitle from './PageTitle';
 
 Router.onRouteChangeStart = () => {
   NProgress.start();
@@ -82,58 +82,62 @@ class AppFrame extends React.Component {
 
   render() {
     const { children, classes } = this.props;
-    const { activePage } = this.context;
-    const title = activePage.title !== false ? pageToTitle(activePage) : null;
-
-    let disablePermanent = false;
-    let navIconClassName = '';
-    let appBarClassName = classes.appBar;
-
-    if (title === null) {
-      // home route, don't shift app bar or dock drawer
-      disablePermanent = true;
-      appBarClassName += ` ${classes.appBarHome}`;
-    } else {
-      navIconClassName = classes.navIconHide;
-      appBarClassName += ` ${classes.appBarShift}`;
-    }
-    // Disable box-shadow for pages wrapped by AppContent.
-    // Those pages have a breadcrumb box.
-    if (RegExp('admin').test(activePage.pathname)) {
-      appBarClassName += ` ${classes.appBarHome}`;
-    }
 
     return (
-      <div className={classes.root}>
-        <NProgressBar />
-        <AppBar className={appBarClassName}>
-          <Toolbar>
-            <IconButton
-              color="inherit"
-              aria-label="open drawer"
-              onClick={this.handleDrawerOpen}
-              className={navIconClassName}
-            >
-              <MenuIcon />
-            </IconButton>
-            {title !== null && (
-              <Typography className={classes.title} variant="h6" color="inherit" noWrap>
-                {title}
-              </Typography>
-            )}
-            <div className={classes.grow} />
-            <UserMenuAppBar />
-          </Toolbar>
-        </AppBar>
-        <AppDrawer
-          className={classes.drawer}
-          disablePermanent={disablePermanent}
-          onClose={this.handleDrawerClose}
-          onOpen={this.handleDrawerOpen}
-          mobileOpen={this.state.mobileOpen}
-        />
-        {children}
-      </div>
+      <PageTitle>
+        {title => {
+          let disablePermanent = false;
+          let navIconClassName = '';
+          let appBarClassName = classes.appBar;
+
+          if (title === null) {
+            // home route, don't shift app bar or dock drawer
+            disablePermanent = true;
+            appBarClassName += ` ${classes.appBarHome}`;
+          } else {
+            navIconClassName = classes.navIconHide;
+            appBarClassName += ` ${classes.appBarShift}`;
+          }
+          // Disable box-shadow for pages wrapped by AppContent.
+          // Those pages have a breadcrumb box.
+          // if (RegExp('admin').test(activePage.pathname)) {
+          //   appBarClassName += ` ${classes.appBarHome}`;
+          // }
+
+          return (
+            <div className={classes.root}>
+              <NProgressBar />
+              <AppBar className={appBarClassName}>
+                <Toolbar>
+                  <IconButton
+                    color="inherit"
+                    aria-label="open drawer"
+                    onClick={this.handleDrawerOpen}
+                    className={navIconClassName}
+                  >
+                    <MenuIcon />
+                  </IconButton>
+                  {title !== null && (
+                    <Typography className={classes.title} variant="h6" color="inherit" noWrap>
+                      {title}
+                    </Typography>
+                  )}
+                  <div className={classes.grow} />
+                  <UserMenuAppBar />
+                </Toolbar>
+              </AppBar>
+              <AppDrawer
+                className={classes.drawer}
+                disablePermanent={disablePermanent}
+                onClose={this.handleDrawerClose}
+                onOpen={this.handleDrawerOpen}
+                mobileOpen={this.state.mobileOpen}
+              />
+              {children}
+            </div>
+          );
+        }}
+      </PageTitle>
     );
   }
 }
@@ -141,12 +145,6 @@ class AppFrame extends React.Component {
 AppFrame.propTypes = {
   children: PropTypes.node.isRequired,
   classes: PropTypes.object.isRequired,
-};
-
-AppFrame.contextTypes = {
-  activePage: PropTypes.shape({
-    pathname: PropTypes.string.isRequired,
-  }).isRequired,
 };
 
 export default withStyles(styles, { name: 'AppFrame' })(AppFrame);

--- a/frontend/src/components/AppFrame.js
+++ b/frontend/src/components/AppFrame.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import NProgress from 'nprogress';
+// O NProgressBar da versão 3.0.0-alpha.7 do @material-ui/docs não está
+// funcionando com o Material-UI v3.5.1, então eu copiei o componente.
+import NProgressBar from './NProgressBar';
 import Router from 'next/router';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
@@ -11,16 +14,6 @@ import MenuIcon from '@material-ui/icons/Menu';
 import AppDrawer from './AppDrawer';
 import { pageToTitle } from '../utils/helpers';
 import UserMenuAppBar from './UserMenuAppBar';
-
-// Disaply a progress bar between route transitions
-NProgress.configure({
-  template: `
-    <div class="bar" role="bar">
-      <dt></dt>
-      <dd></dd>
-    </div>
-  `,
-});
 
 Router.onRouteChangeStart = () => {
   NProgress.start();
@@ -35,55 +28,6 @@ Router.onRouteChangeError = () => {
 };
 
 const styles = theme => ({
-  '@global': {
-    '#nprogress': {
-      pointerEvents: 'none',
-      '& .bar': {
-        position: 'fixed',
-        background:
-          theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
-        borderRadius: 1,
-        zIndex: theme.zIndex.tooltip,
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: 2,
-      },
-      '& dd, & dt': {
-        position: 'absolute',
-        top: 0,
-        height: 2,
-        boxShadow: `${
-          theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white
-        } 1px 0 6px 1px`,
-        borderRadius: '100%',
-        animation: 'nprogress-pulse 2s ease-out 0s infinite',
-      },
-      '& dd': {
-        opacity: 0.6,
-        width: 20,
-        right: 0,
-        clip: 'rect(-6px,22px,14px,10px)',
-      },
-      '& dt': {
-        opacity: 0.6,
-        width: 180,
-        right: -80,
-        clip: 'rect(-6px,90px,14px,-6px)',
-      },
-    },
-    '@keyframes nprogress-pulse': {
-      '30%': {
-        opacity: 0.6,
-      },
-      '60%': {
-        opacity: 0,
-      },
-      to: {
-        opacity: 0.6,
-      },
-    },
-  },
   root: {
     display: 'flex',
     alignItems: 'stretch',
@@ -161,6 +105,7 @@ class AppFrame extends React.Component {
 
     return (
       <div className={classes.root}>
+        <NProgressBar />
         <AppBar className={appBarClassName}>
           <Toolbar>
             <IconButton

--- a/frontend/src/components/AppWrapper.js
+++ b/frontend/src/components/AppWrapper.js
@@ -1,0 +1,68 @@
+/* eslint-disable no-underscore-dangle */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MuiThemeProvider } from '@material-ui/core/styles';
+import JssProvider from 'react-jss/lib/JssProvider';
+import getPageContext from '../utils/getPageContext';
+import CssBaseline from '@material-ui/core/CssBaseline';
+
+// Inject the <!--insertion-point-jss--> at the end of <head> (see pages/_document.js)
+if (process.browser && !global.__INSERTION_POINT__) {
+  global.__INSERTION_POINT__ = true;
+  const styleNode = document.createComment('insertion-point-jss');
+  const endOfHeadInsertionPoint = document.querySelector('#end-of-head-insertion-point');
+
+  if (document.head && endOfHeadInsertionPoint) {
+    document.head.insertBefore(styleNode, endOfHeadInsertionPoint);
+  }
+}
+
+class AppWrapper extends React.Component {
+  state = {};
+
+  componentDidMount() {
+    // Remove the server-side injected CSS.
+    const jssStyles = document.querySelector('#jss-server-side');
+    if (jssStyles && jssStyles.parentNode) {
+      jssStyles.parentNode.removeChild(jssStyles);
+    }
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (typeof prevState.pageContext === 'undefined') {
+      return {
+        prevProps: nextProps,
+        pageContext: nextProps.pageContext || getPageContext(),
+      };
+    }
+
+    return null;
+  }
+
+  render() {
+    const { children } = this.props;
+    const { pageContext } = this.state;
+
+    return (
+      <JssProvider
+        jss={pageContext.jss}
+        registry={pageContext.sheetsRegistry}
+        generateClassName={pageContext.generateClassName}
+      >
+        <MuiThemeProvider theme={pageContext.theme} sheetsManager={pageContext.sheetsManager}>
+          <CssBaseline />
+          {children}
+        </MuiThemeProvider>
+      </JssProvider>
+    );
+  }
+}
+
+AppWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  // eslint-disable-next-line react/no-unused-prop-types
+  pageContext: PropTypes.object,
+};
+
+export default AppWrapper;

--- a/frontend/src/components/Link.js
+++ b/frontend/src/components/Link.js
@@ -1,9 +1,12 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import compose from 'recompose/compose';
+import { withRouter } from 'next/router';
 import NextLink from 'next/link';
 import { withStyles } from '@material-ui/core/styles';
-import { capitalize } from '@material-ui/core/utils/helpers';
 
 const styles = theme => ({
   root: {
@@ -12,63 +15,43 @@ const styles = theme => ({
       textDecoration: 'underline',
     },
   },
-  variantDefault: {
+  default: {
     color: 'inherit',
   },
-  variantPrimary: {
+  primary: {
     color: theme.palette.primary.main,
   },
-  variantSecondary: {
+  secondary: {
     color: theme.palette.secondary.main,
   },
-  variantButton: {
+  button: {
     '&:hover': {
       textDecoration: 'inherit',
     },
   },
 });
 
-class OnClick extends React.Component {
-  handleClick = event => {
-    if (this.props.onClick) {
-      this.props.onClick(event);
-    }
-
-    if (this.props.onCustomClick) {
-      this.props.onCustomClick(event);
-    }
-  };
-
-  render() {
-    const { component: ComponentProp, onCustomClick, ...props } = this.props;
-    return <ComponentProp {...props} onClick={this.handleClick} />;
-  }
-}
-
-OnClick.propTypes = {
-  component: PropTypes.string.isRequired,
-  onClick: PropTypes.func,
-  onCustomClick: PropTypes.func,
-};
-
-function Link(props, context) {
+function Link(props) {
   const {
     activeClassName,
     children: childrenProp,
-    component: ComponentProp,
     classes,
     className: classNameProp,
-    variant,
+    component: ComponentProp,
     href,
     onClick,
     prefetch,
+    router,
+    variant,
     ...other
   } = props;
 
   let ComponentRoot;
   const className = classNames(
     classes.root,
-    classes[`variant${capitalize(variant)}`],
+    {
+      [classes[variant]]: variant !== 'inherit',
+    },
     classNameProp,
   );
   let RootProps;
@@ -87,18 +70,16 @@ function Link(props, context) {
       prefetch,
       passHref: true,
     };
-    const active = context.url.pathname === href;
     children = (
-      <OnClick
-        component="a"
+      <a
         className={classNames(className, {
-          [activeClassName]: active && activeClassName,
+          [activeClassName]: router.pathname === href && activeClassName,
         })}
-        onCustomClick={onClick}
+        onClick={onClick}
         {...other}
       >
         {children}
-      </OnClick>
+      </a>
     );
   } else {
     ComponentRoot = 'a';
@@ -116,12 +97,6 @@ Link.defaultProps = {
   activeClassName: 'active',
 };
 
-Link.contextTypes = {
-  url: PropTypes.shape({
-    pathname: PropTypes.string.isRequired,
-  }).isRequired,
-};
-
 Link.propTypes = {
   activeClassName: PropTypes.string,
   children: PropTypes.node.isRequired,
@@ -131,7 +106,13 @@ Link.propTypes = {
   href: PropTypes.string,
   onClick: PropTypes.func,
   prefetch: PropTypes.bool,
-  variant: PropTypes.oneOf(['default', 'primary', 'secondary', 'button']),
+  router: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
+  variant: PropTypes.oneOf(['default', 'primary', 'secondary', 'button', 'inherit']),
 };
 
-export default withStyles(styles)(Link);
+export default compose(
+  withRouter,
+  withStyles(styles),
+)(Link);

--- a/frontend/src/components/NProgressBar.js
+++ b/frontend/src/components/NProgressBar.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import NProgress from 'nprogress';
+import { withStyles } from '@material-ui/core/styles';
+import NoSsr from '@material-ui/core/NoSsr';
+// Isto é temporário, até o @material-ui/docs ser concertado
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { exactProp } from '@material-ui/utils';
+
+NProgress.configure({
+  template: `
+    <div class="nprogress-bar" role="bar">
+      <dt></dt>
+      <dd></dd>
+    </div>
+  `,
+});
+
+const styles = theme => {
+  if (!theme.nprogress.color) {
+    throw new Error(
+      'Material-UI: you need to provide a `theme.nprogress.color` property' +
+        ' for using the `NProgressBar` component.',
+    );
+  }
+
+  return {
+    '@global': {
+      '#nprogress': {
+        direction: 'ltr',
+        pointerEvents: 'none',
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 2,
+        zIndex: theme.zIndex.tooltip,
+        backgroundColor: '#e0e0e0',
+        '& .nprogress-bar': {
+          position: 'fixed',
+          backgroundColor: theme.nprogress.color,
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 2,
+        },
+        '& dd, & dt': {
+          position: 'absolute',
+          top: 0,
+          height: 2,
+          boxShadow: `${theme.nprogress.color} 1px 0 6px 1px`,
+          borderRadius: '100%',
+          animation: 'nprogress-pulse 2s ease-out 0s infinite',
+        },
+        '& dd': {
+          opacity: 0.6,
+          width: 20,
+          right: 0,
+          clip: 'rect(-6px,22px,14px,10px)',
+        },
+        '& dt': {
+          opacity: 0.6,
+          width: 180,
+          right: -80,
+          clip: 'rect(-6px,90px,14px,-6px)',
+        },
+      },
+      '@keyframes nprogress-pulse': {
+        '30%': {
+          opacity: 0.6,
+        },
+        '60%': {
+          opacity: 0,
+        },
+        to: {
+          opacity: 0.6,
+        },
+      },
+    },
+  };
+};
+
+const GlobalStyles = withStyles(styles, { flip: false, name: 'MuiNProgressBar' })(() => null);
+
+/**
+ * Elegant and ready to use wrapper on top of https://github.com/rstacruz/nprogress/.
+ * The implementation is highly inspired by the YouTube one.
+ */
+function NProgressBar(props) {
+  return (
+    <NoSsr>
+      {props.children}
+      <GlobalStyles />
+    </NoSsr>
+  );
+}
+
+NProgressBar.propTypes = {
+  children: PropTypes.node,
+};
+
+NProgressBar.propTypes = exactProp(NProgressBar.propTypes, 'NProgressBar');
+
+NProgressBar.defaultProps = {
+  children: null,
+};
+
+export default NProgressBar;

--- a/frontend/src/components/PageContext.js
+++ b/frontend/src/components/PageContext.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+// The default value is never and should never be used.
+// It's here to improve DX by enabling autocompletion for editors supporting TypeScript.
+const PageContext = React.createContext({
+  activePage: {
+    pathname: '',
+  },
+  loggedInUser: {
+    email: '',
+  },
+  pages: [],
+});
+
+export default PageContext;

--- a/frontend/src/components/PageTitle.js
+++ b/frontend/src/components/PageTitle.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { pageToTitle } from '../utils/helpers';
+import PageContext from './PageContext';
+
+// TODO: it really wants to be named useTitle but we're not quite there yet.
+function PageTitle(props) {
+  return (
+    <PageContext.Consumer>
+      {({ activePage }) => {
+        if (!activePage) {
+          throw new Error('Missing activePage.');
+        }
+
+        const title = activePage.title !== false ? pageToTitle(activePage) : null;
+        return props.children(title);
+      }}
+    </PageContext.Consumer>
+  );
+}
+
+PageTitle.propTypes = {
+  children: PropTypes.func.isRequired,
+};
+
+export default PageTitle;

--- a/frontend/src/components/UserMenuAppBar.js
+++ b/frontend/src/components/UserMenuAppBar.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import AccountCircle from '@material-ui/icons/AccountCircle';
@@ -8,6 +7,7 @@ import cookie from 'cookie';
 import { withApollo } from 'react-apollo';
 import Link from './Link';
 import redirect from '../utils/redirect';
+import PageContext from './PageContext';
 
 class UserMenuAppBar extends React.Component {
   state = {
@@ -39,51 +39,55 @@ class UserMenuAppBar extends React.Component {
     const { anchorEl } = this.state;
     const open = Boolean(anchorEl);
 
-    if (this.context.loggedInUser.me) {
-      return (
-        <div>
-          <IconButton
-            aria-owns={open ? 'menu-appbar' : null}
-            aria-haspopup="true"
-            onClick={this.handleMenu}
-            color="inherit"
-          >
-            <AccountCircle />
-          </IconButton>
-          <Menu
-            id="menu-appbar"
-            anchorEl={anchorEl}
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-            open={open}
-            onClose={this.handleClose}
-          >
-            <MenuItem onClick={this.handleClose}>Perfil</MenuItem>
-            <MenuItem onClick={this.handleClose}>Minha Conta</MenuItem>
-            <MenuItem onClick={this.logout}>Sair</MenuItem>
-          </Menu>
-        </div>
-      );
-    }
     return (
-      <Button
-        color="inherit"
-        component={buttonProps => <Link variant="button" prefetch href="/login" {...buttonProps} />}
-      >
-        Login
-      </Button>
+      <PageContext.Consumer>
+        {({ loggedInUser }) => {
+          if (loggedInUser.me) {
+            return (
+              <div>
+                <IconButton
+                  aria-owns={open ? 'menu-appbar' : null}
+                  aria-haspopup="true"
+                  onClick={this.handleMenu}
+                  color="inherit"
+                >
+                  <AccountCircle />
+                </IconButton>
+                <Menu
+                  id="menu-appbar"
+                  anchorEl={anchorEl}
+                  anchorOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right',
+                  }}
+                  transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right',
+                  }}
+                  open={open}
+                  onClose={this.handleClose}
+                >
+                  <MenuItem onClick={this.handleClose}>Perfil</MenuItem>
+                  <MenuItem onClick={this.handleClose}>Minha Conta</MenuItem>
+                  <MenuItem onClick={this.logout}>Sair</MenuItem>
+                </Menu>
+              </div>
+            );
+          }
+          return (
+            <Button
+              color="inherit"
+              component={buttonProps => (
+                <Link variant="button" prefetch href="/login" {...buttonProps} />
+              )}
+            >
+              Login
+            </Button>
+          );
+        }}
+      </PageContext.Consumer>
     );
   }
 }
-
-UserMenuAppBar.contextTypes = {
-  loggedInUser: PropTypes.object,
-};
 
 export default withApollo(UserMenuAppBar);

--- a/frontend/src/pages/_document.js
+++ b/frontend/src/pages/_document.js
@@ -40,19 +40,24 @@ MyDocument.getInitialProps = ctx => {
   // Resolution order
   //
   // On the server:
-  // 1. page.getInitialProps
-  // 2. document.getInitialProps
-  // 3. page.render
-  // 4. document.render
+  // 1. app.getInitialProps
+  // 2. page.getInitialProps
+  // 3. document.getInitialProps
+  // 4. app.render
+  // 5. page.render
+  // 6. document.render
   //
   // On the server with error:
-  // 2. document.getInitialProps
+  // 1. document.getInitialProps
+  // 2. app.render
   // 3. page.render
   // 4. document.render
   //
   // On the client
-  // 1. page.getInitialProps
-  // 3. page.render
+  // 1. app.getInitialProps
+  // 2. page.getInitialProps
+  // 3. app.render
+  // 4. page.render
 
   // Get the context of the page to collected side effects.
   const pageContext = getPageContext();

--- a/frontend/src/pages/_document.js
+++ b/frontend/src/pages/_document.js
@@ -13,10 +13,7 @@ class MyDocument extends Document {
           {/* Use minimum-scale=1 to enable GPU rasterization */}
           <meta
             name="viewport"
-            content={
-              'user-scalable=0, initial-scale=1, ' +
-              'minimum-scale=1, width=device-width, height=device-height'
-            }
+            content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
           />
           {/* PWA primary color */}
           <meta name="theme-color" content={pageContext.theme.palette.primary[500]} />

--- a/frontend/src/pages/_document.js
+++ b/frontend/src/pages/_document.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
-import JssProvider from 'react-jss/lib/JssProvider';
 import getPageContext from '../utils/getPageContext';
 
 class MyDocument extends Document {
@@ -26,6 +25,7 @@ class MyDocument extends Document {
             href="https://fonts.googleapis.com/css?family=Roboto:300,400,500"
           />
           <link rel="shortcut icon" href="/static/favicon.ico" />
+          <style id="end-of-head-insertion-point" />
         </Head>
         <body>
           <Main />
@@ -57,12 +57,7 @@ MyDocument.getInitialProps = ctx => {
   // Get the context of the page to collected side effects.
   const pageContext = getPageContext();
   const page = ctx.renderPage(Component => props => (
-    <JssProvider
-      registry={pageContext.sheetsRegistry}
-      generateClassName={pageContext.generateClassName}
-    >
-      <Component pageContext={pageContext} {...props} />
-    </JssProvider>
+    <Component pageContext={pageContext} {...props} />
   ));
 
   return {

--- a/frontend/src/pages/admin/index.js
+++ b/frontend/src/pages/admin/index.js
@@ -1,8 +1,6 @@
-// Transform these into import AppFrame from 'components/AppFrame'
+// TODO: Transform these into import AppFrame from 'components/AppFrame'
 // https://daveceddia.com/react-project-structure/
 import React from 'react';
-import compose from 'recompose/compose';
-import withData from '../../utils/withData';
 import withRoot from '../../utils/withRoot';
 import AppFrame from '../../components/AppFrame';
 import AppContent from '../../components/AppContent';
@@ -16,7 +14,4 @@ const PageAdmin = () => (
   </AppFrame>
 );
 
-export default compose(
-  withRoot,
-  withData,
-)(PageAdmin);
+export default withRoot(PageAdmin);

--- a/frontend/src/pages/criar_conta.js
+++ b/frontend/src/pages/criar_conta.js
@@ -17,8 +17,8 @@ function PageSignUp(props) {
   );
 }
 
-PageSignUp.getInitialProps = async (context, apolloClient) => {
-  const { loggedInUser } = await checkLoggedIn(context, apolloClient);
+PageSignUp.getInitialProps = async context => {
+  const { loggedInUser } = await checkLoggedIn(context.apolloClient);
 
   if (loggedInUser.me) {
     // Already signed in? No need to continue.

--- a/frontend/src/pages/login.js
+++ b/frontend/src/pages/login.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { compose } from 'react-apollo';
 import Head from 'next/head';
 import OnlyFormFrame from '../components/OnlyFormFrame';
 import LoginForm from '../components/LoginForm';
@@ -21,7 +20,6 @@ function PageLogin() {
 PageLogin.getInitialProps = async context => {
   const { loggedInUser } = await checkLoggedIn(context.apolloClient);
 
-  // if (loggedInUser.user) {
   if (loggedInUser.me) {
     // Already signed in? No need to continue.
     // Throw them back to the main page
@@ -31,8 +29,4 @@ PageLogin.getInitialProps = async context => {
   return {};
 };
 
-export default compose(
-  withRoot,
-  // withData gives us server-side graphql queries before rendering
-  // withData,
-)(PageLogin);
+export default withRoot(PageLogin);

--- a/frontend/src/pages/login.js
+++ b/frontend/src/pages/login.js
@@ -18,8 +18,8 @@ function PageLogin() {
   );
 }
 
-PageLogin.getInitialProps = async (context, apolloClient) => {
-  const { loggedInUser } = await checkLoggedIn(context, apolloClient);
+PageLogin.getInitialProps = async context => {
+  const { loggedInUser } = await checkLoggedIn(context.apolloClient);
 
   // if (loggedInUser.user) {
   if (loggedInUser.me) {

--- a/frontend/src/utils/checkLoggedIn.js
+++ b/frontend/src/utils/checkLoggedIn.js
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-export default (context, apolloClient) =>
+export default apolloClient =>
   apolloClient
     .query({
       query: gql`

--- a/frontend/src/utils/getPageContext.js
+++ b/frontend/src/utils/getPageContext.js
@@ -8,6 +8,7 @@ import blue from '@material-ui/core/colors/blue';
 // A theme with custom primary and secondary color.
 // It's optional.
 const theme = createMuiTheme({
+  nprogress: { color: '#000' },
   palette: {
     primary: {
       main: '#1e88e5',

--- a/frontend/src/utils/withData.js
+++ b/frontend/src/utils/withData.js
@@ -36,11 +36,12 @@ export default ComposedComponent => {
           getToken: () => parseCookies(context).token,
         },
       );
+      context.apolloClient = apollo;
 
       // Evaluate the composed component's getInitialProps()
       let composedInitialProps = {};
       if (ComposedComponent.getInitialProps) {
-        composedInitialProps = await ComposedComponent.getInitialProps(context, apollo);
+        composedInitialProps = await ComposedComponent.getInitialProps(context);
       }
 
       // Run all GraphQL queries in the component tree

--- a/frontend/src/utils/withData.js
+++ b/frontend/src/utils/withData.js
@@ -72,6 +72,8 @@ export default ComposedComponent => {
           // Prevent Apollo Client GraphQL errors from crashing SSR.
           // Handle them in components via the data.error prop:
           // http://dev.apollodata.com/react/api-queries.html#graphql-query-data-error
+          // eslint-disable-next-line no-console
+          console.error('Error while running `getDataFromTree`', error);
         }
 
         if (!process.browser) {

--- a/frontend/src/utils/withRoot.js
+++ b/frontend/src/utils/withRoot.js
@@ -158,6 +158,7 @@ function findActivePage(currentPages, router) {
 }
 
 function withRoot(Component) {
+  // eslint-disable-next-line react/prefer-stateless-function
   class WithRoot extends React.Component {
     render() {
       const { loggedInUser, pageContext, ...otherProps } = this.props;
@@ -179,13 +180,6 @@ function withRoot(Component) {
     loggedInUser: PropTypes.object,
     pageContext: PropTypes.object,
     router: PropTypes.object.isRequired,
-  };
-
-  WithRoot.childContextTypes = {
-    url: PropTypes.object,
-    pages: PropTypes.array,
-    activePage: PropTypes.object,
-    loggedInUser: PropTypes.object,
   };
 
   WithRoot.getInitialProps = async ctx => {

--- a/frontend/src/utils/withRoot.js
+++ b/frontend/src/utils/withRoot.js
@@ -97,6 +97,7 @@ const pages = [
   },
   {
     pathname: '/',
+    displayNav: false,
     title: false,
   },
   {

--- a/frontend/src/utils/withRoot.js
+++ b/frontend/src/utils/withRoot.js
@@ -190,12 +190,12 @@ function withRoot(Component) {
     loggedInUser: PropTypes.object,
   };
 
-  WithRoot.getInitialProps = async (ctx, apollo) => {
-    const { loggedInUser } = await checkLoggedIn(ctx, apollo);
+  WithRoot.getInitialProps = async ctx => {
+    const { loggedInUser } = await checkLoggedIn(ctx.apolloClient);
 
     let composedInitialProps = {};
     if (Component.getInitialProps) {
-      composedInitialProps = Component.getInitialProps(ctx, apollo);
+      composedInitialProps = Component.getInitialProps(ctx);
     }
 
     return { loggedInUser, ...composedInitialProps };

--- a/frontend/src/utils/withRoot.js
+++ b/frontend/src/utils/withRoot.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import find from 'lodash/find';
-import { MuiThemeProvider } from '@material-ui/core/styles';
-import CssBaseline from '@material-ui/core/CssBaseline';
-import getPageContext from './getPageContext';
 import checkLoggedIn from './checkLoggedIn';
 import withData from './withData';
+import AppWrapper from '../components/AppWrapper';
 
 const pages = [
   {
@@ -169,30 +167,13 @@ function withRoot(Component) {
       };
     }
 
-    componentWillMount() {
-      this.pageContext = this.props.pageContext || getPageContext();
-    }
-
-    componentDidMount() {
-      // Remove the server-side injected CSS.
-      const jssStyles = document.querySelector('#jss-server-side');
-      if (jssStyles && jssStyles.parentNode) {
-        jssStyles.parentNode.removeChild(jssStyles);
-      }
-    }
-
-    pageContext = null;
-
     render() {
-      // MuiThemeProvider makes the theme available down the React tree thanks to React context.
+      const { pageContext } = this.props;
+
       return (
-        <MuiThemeProvider
-          theme={this.pageContext.theme}
-          sheetsManager={this.pageContext.sheetsManager}
-        >
-          <CssBaseline />
+        <AppWrapper pageContext={pageContext}>
           <Component {...this.props} />
-        </MuiThemeProvider>
+        </AppWrapper>
       );
     }
   }


### PR DESCRIPTION
Esse PR adiciona algumas alterações feitas na aplicação web do [Material-UI](https://github.com/mui-org/material-ui/tree/master/docs) (de onde eu copiei o layout pra usar _Next.js_ e _Material-UI_ juntos). Essas alterações são baseadas na versão antes deles começarem a usar `@material-ui/styles`, que precisa da versão alpha do React.js:

- Introdução do `@material-ui/styles`: [@material-ui/styles (#13503)](https://github.com/mui-org/material-ui/commit/83adb95e594d7799b5f399a824f0d72f749ba349);
- Um commit antes: [[docs] Add cookie for persistant colors (#13567)](https://github.com/mui-org/material-ui/tree/adcf8ac6787b90787b4bb23f0f10cff8de1c8047/docs).