### PR TITLE
Paginação pra lista de questões

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -248,6 +248,7 @@
       "version": "1.6.0",
       "resolved": "http://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -306,6 +307,7 @@
       "version": "0.0.33",
       "resolved": "http://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
       "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -327,7 +329,8 @@
     "@types/methods": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.0.tgz",
-      "integrity": "sha512-ROomEm+QHlUmcQoDr3CBo3GRm0w4PVoFYjVT9YcfyBha/Per4deb1IpvHU7KTK7YBZCIvOYbSADoEyDnFgaWLA=="
+      "integrity": "sha512-ROomEm+QHlUmcQoDr3CBo3GRm0w4PVoFYjVT9YcfyBha/Per4deb1IpvHU7KTK7YBZCIvOYbSADoEyDnFgaWLA==",
+      "dev": true
     },
     "@types/mime": {
       "version": "2.0.0",
@@ -379,7 +382,8 @@
     "@types/tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-Set5ZdrAaKI/qHdFlVMgm/GsAv/wkXhSTuZFkJ+JI7HK+wIkIlOaUXSXieIvJ0+OvGIqtREFoE+NHJtEq0gtEw=="
+      "integrity": "sha512-Set5ZdrAaKI/qHdFlVMgm/GsAv/wkXhSTuZFkJ+JI7HK+wIkIlOaUXSXieIvJ0+OvGIqtREFoE+NHJtEq0gtEw==",
+      "dev": true
     },
     "@types/ws": {
       "version": "6.0.1",
@@ -1120,7 +1124,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -2365,6 +2370,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2452,6 +2458,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -2462,17 +2469,20 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -2487,6 +2497,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -2952,7 +2963,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -3835,6 +3847,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -5739,6 +5752,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
+      "dev": true,
       "requires": {
         "make-error": "^1.2.0"
       }
@@ -6141,7 +6155,8 @@
     "node-fetch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+      "dev": true
     },
     "node-forge": {
       "version": "0.7.6",
@@ -6879,12 +6894,14 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
     },
     "popsicle": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-10.0.1.tgz",
       "integrity": "sha512-IFVBRz+hc05+MiVDH+KH9QoeE6gjFOiIZNxKePIwz+JbH/yP9rLreUT9+GocxRweYBiRh7O9+MfI5X1zKfSH6Q==",
+      "dev": true,
       "requires": {
         "@types/concat-stream": "^1.6.0",
         "@types/form-data": "0.0.33",
@@ -7804,9 +7821,9 @@
       }
     },
     "prisma-client-lib": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/prisma-client-lib/-/prisma-client-lib-1.21.0.tgz",
-      "integrity": "sha512-w0HElBoWf5NVBSfGcXEmxxTx3Nfuieh6Mu81UZISdDgePFsIC67L4gcWS1imIy2zPs47GxhAA5c8OE/NdSdCGw==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/prisma-client-lib/-/prisma-client-lib-1.20.1.tgz",
+      "integrity": "sha512-ZLkQUasaL1Y7s5wUcs0a8rpyGgV/oHoxmz9H05R38I7vBVGAGqAxWIfX0Hb/OhRUOn6orZ9bCdZnHeiryPhrGg==",
       "requires": {
         "@types/node": "^10.12.0",
         "@types/prettier": "^1.13.2",
@@ -7816,7 +7833,6 @@
         "jsonwebtoken": "^8.3.0",
         "lodash.flatten": "^4.4.0",
         "prettier": "^1.14.3",
-        "prisma-generate-schema": "1.21.0",
         "subscriptions-transport-ws": "^0.9.15",
         "uppercamelcase": "^3.0.0",
         "ws": "^6.1.0",
@@ -7954,6 +7970,7 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/prisma-generate-schema/-/prisma-generate-schema-1.21.0.tgz",
       "integrity": "sha512-dPvU4fukfBKab29ROaH/GSXPkwedFCJywhGv9Punu6pm3r9A9+g4s+vGHwcXNBLYk3SHGfTE/kI8/E6o/Mueug==",
+      "dev": true,
       "requires": {
         "graphql": "^14.0.2",
         "node-fetch": "^2.2.1",
@@ -7965,6 +7982,7 @@
           "version": "14.0.2",
           "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
           "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
+          "dev": true,
           "requires": {
             "iterall": "^1.2.2"
           }
@@ -7972,7 +7990,8 @@
         "iterall": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-          "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+          "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
+          "dev": true
         }
       }
     },
@@ -8143,7 +8162,8 @@
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "dev": true
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -9527,6 +9547,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -9535,7 +9556,8 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         }
       }
     },
@@ -9687,7 +9709,8 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typescript": {
       "version": "3.1.3",
@@ -9951,7 +9974,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,7 @@
     "mime-types": "^2.1.21",
     "mv": "^2.1.1",
     "prisma-binding": "^2.1.6",
-    "prisma-client-lib": "^1.21.0",
+    "prisma-client-lib": "^1.20.1",
     "shortid": "^2.2.14"
   },
   "devDependencies": {

--- a/backend/src/resolvers/Query.ts
+++ b/backend/src/resolvers/Query.ts
@@ -51,6 +51,10 @@ export const Query = {
     }));
   },
 
+  questionsConnection(parent, args, ctx: Context, info) {
+    return ctx.prismaBinding.query.questionsConnection(args, info);
+  },
+
   async schools(parent, args, ctx: Context, info) {
     // The prisma-client api is different, it only returns scalar fields
     const schools = await ctx.db.schools({});

--- a/backend/src/schema.graphql
+++ b/backend/src/schema.graphql
@@ -10,6 +10,14 @@ type Query {
   olympiadsFeed(first: Int, after: String): OlympiadFeed!
   question(id: ID!): Question
   questions: [Question!]!
+  questionsConnection(
+    where: QuestionWhereInput
+    orderBy: QuestionOrderByInput
+    skip: Int
+    after: String
+    before: String
+    first: Int
+    last: Int): QuestionConnection!
   schools: [School!]!
   school(id: ID!): School
   tests: [Test!]!

--- a/frontend/src/components/FAButton.js
+++ b/frontend/src/components/FAButton.js
@@ -7,6 +7,8 @@ const styles = theme => ({
     position: 'absolute',
     top: -28,
     left: theme.spacing.unit * -6,
+    // Para o botão ficar por cima das imagens do Card
+    zIndex: theme.zIndex.mobileStepper,
   },
   [theme.breakpoints.down(1000 + theme.spacing.unit * 8)]: {
     FAButton: {

--- a/frontend/src/components/LoadMoreButton.js
+++ b/frontend/src/components/LoadMoreButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, withStyles } from '@material-ui/core';
+import { Button, withStyles, CircularProgress } from '@material-ui/core';
 import { compose, withState } from 'recompose';
 
 const styles = theme => ({
@@ -12,6 +12,8 @@ const styles = theme => ({
     marginLeft: 'auto',
     marginRight: 'auto',
     display: 'table',
+    // Fixa a altura, porque o CircularProgress aumenta o botão
+    height: 40,
   },
   [theme.breakpoints.up('sm')]: {
     loadMoreButton: {
@@ -40,7 +42,7 @@ const LoadMoreButton = ({ children, classes, loading, onLoadMore, setLoading }) 
       size="large"
       variant="outlined"
     >
-      {children}
+      {loading ? <CircularProgress size={22} /> : children}
     </Button>
   );
 };

--- a/frontend/src/components/LoadMoreButton.js
+++ b/frontend/src/components/LoadMoreButton.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, withStyles, CircularProgress } from '@material-ui/core';
-import { compose, withState } from 'recompose';
 
 const styles = theme => ({
   loadMoreButton: {
@@ -26,34 +25,17 @@ const styles = theme => ({
   },
 });
 
-const LoadMoreButton = ({
-  children,
-  classes,
-  hasMore,
-  loading,
-  onLoadMore,
-  setHasMore,
-  setLoading,
-}) => {
+const LoadMoreButton = ({ children, classes, loadingMore, hasMore, onLoadMore }) => {
   return (
     <Button
-      onClick={async () => {
-        setLoading(true);
-        // A função fetchMore() do Apollo Client retorna Promise<ApolloQueryResult>
-        const result = await onLoadMore();
-        // Isto está acoplado com a questionsConnection.
-        // Este estado deveria ficar no ListConnector, e os valores passados como props:
-        // 'fetchingMore' e 'hasMore'.
-        setHasMore(result.data.questionsConnection.pageInfo.hasNextPage);
-        setLoading(false);
-      }}
-      disabled={loading || !hasMore}
+      onClick={onLoadMore}
+      disabled={loadingMore || !hasMore}
       className={classes.loadMoreButton}
       color="primary"
       size="large"
       variant="outlined"
     >
-      {loading ? <CircularProgress size={22} /> : children}
+      {loadingMore ? <CircularProgress size={22} /> : children}
     </Button>
   );
 };
@@ -62,14 +44,8 @@ LoadMoreButton.propTypes = {
   children: PropTypes.node.isRequired,
   classes: PropTypes.object.isRequired,
   hasMore: PropTypes.bool.isRequired,
-  loading: PropTypes.bool.isRequired,
+  loadingMore: PropTypes.bool.isRequired,
   onLoadMore: PropTypes.func,
-  setHasMore: PropTypes.func.isRequired,
-  setLoading: PropTypes.func.isRequired,
 };
 
-export default compose(
-  withState('hasMore', 'setHasMore', true),
-  withState('loading', 'setLoading', false),
-  withStyles(styles),
-)(LoadMoreButton);
+export default withStyles(styles)(LoadMoreButton);

--- a/frontend/src/components/LoadMoreButton.js
+++ b/frontend/src/components/LoadMoreButton.js
@@ -5,7 +5,6 @@ import { compose, withState } from 'recompose';
 
 const styles = theme => ({
   loadMoreButton: {
-    borderStyle: 'dashed',
     marginTop: theme.spacing.unit * 2,
     width: '100%',
     // Centraliza o botão verticalmente

--- a/frontend/src/components/LoadMoreButton.js
+++ b/frontend/src/components/LoadMoreButton.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, withStyles } from '@material-ui/core';
+import { compose, withState } from 'recompose';
 
 const styles = theme => ({
   loadMoreButton: {
     borderStyle: 'dashed',
     marginTop: theme.spacing.unit * 2,
     width: '100%',
+    // Centraliza o botão verticalmente
     marginLeft: 'auto',
     marginRight: 'auto',
     display: 'table',
@@ -23,10 +25,16 @@ const styles = theme => ({
   },
 });
 
-const LoadMoreButton = ({ children, classes, onClick }) => {
+const LoadMoreButton = ({ children, classes, loading, onLoadMore, setLoading }) => {
   return (
     <Button
-      onClick={onClick}
+      onClick={async () => {
+        setLoading(true);
+        // A função fetchMore() do Apollo Client retorna Promise<ApolloQueryResult>
+        await onLoadMore();
+        setLoading(false);
+      }}
+      disabled={loading}
       className={classes.loadMoreButton}
       color="primary"
       size="large"
@@ -40,7 +48,12 @@ const LoadMoreButton = ({ children, classes, onClick }) => {
 LoadMoreButton.propTypes = {
   children: PropTypes.node.isRequired,
   classes: PropTypes.object.isRequired,
-  onClick: PropTypes.func,
+  loading: PropTypes.bool.isRequired,
+  onLoadMore: PropTypes.func,
+  setLoading: PropTypes.func.isRequired,
 };
 
-export default withStyles(styles)(LoadMoreButton);
+export default compose(
+  withState('loading', 'setLoading', false),
+  withStyles(styles),
+)(LoadMoreButton);

--- a/frontend/src/components/LoadMoreButton.js
+++ b/frontend/src/components/LoadMoreButton.js
@@ -25,20 +25,75 @@ const styles = theme => ({
   },
 });
 
-const LoadMoreButton = ({ children, classes, loadingMore, hasMore, onLoadMore }) => {
-  return (
-    <Button
-      onClick={onLoadMore}
-      disabled={loadingMore || !hasMore}
-      className={classes.loadMoreButton}
-      color="primary"
-      size="large"
-      variant="outlined"
-    >
-      {loadingMore ? <CircularProgress size={22} /> : children}
-    </Button>
-  );
-};
+class LoadMoreButton extends React.Component {
+  state = {
+    tooLong: false,
+  };
+
+  // Contador usado p/ atrasar a apresentação da animação do CircularProgress.
+  // Veja: https://www.nngroup.com/articles/response-times-3-important-limits/
+  tooLongTimer = undefined;
+
+  componentWillReceiveProps({ loadingMore }) {
+    const { tooLong } = this.state;
+    if (loadingMore === this.props.loadingMore) {
+      // console.log('loadingMore is the same. leaving...');
+      return;
+    }
+    // console.log(`tooLong: ${tooLong} | loadingMore: ${loadingMore}`);
+    // console.log(`Timer: ${this.tooLongTimer}`);
+
+    // Apollo Client está carregando os dados, mas não faz nem 800ms
+    if (!this.tooLongTimer && loadingMore && !tooLong) {
+      // console.log('Setting timer');
+      // Depois de 800ms o usuário precisa saber que ainda estamos esperando
+      this.tooLongTimer = setTimeout(() => {
+        // console.log(`Timeout: tooLong is true.`);
+        this.setState({ tooLong: true });
+      }, 800);
+
+      // Se o Apollo Client não está mais carregando, e tooLong = true,
+      // quer dizer que os dados já foram carregados.
+    } else if (!loadingMore && tooLong) {
+      // Então precisamos zerar o contador.
+      this.setState({ tooLong: false });
+      clearTimeout(this.tooLongTimer);
+      this.tooLongTimer = undefined;
+      // console.log('Timer cleared');
+
+      // Se um contador foi disparado, tooLong = false, e loadingMore = false,
+      // então os dados foram carregados antes dos 800ms.
+    } else if (this.tooLongTimer && !tooLong) {
+      this.setState({ tooLong: false });
+      clearTimeout(this.tooLongTimer);
+      this.tooLongTimer = undefined;
+      // console.log(`Very fast fetching, clearing timer: ${this.tooLongTimer}`);
+    }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.tooLongTimer);
+  }
+
+  render() {
+    const { children, classes, loadingMore, hasMore, onLoadMore } = this.props;
+    const { tooLong } = this.state;
+
+    return (
+      <Button
+        onClick={onLoadMore}
+        disabled={loadingMore || !hasMore}
+        className={classes.loadMoreButton}
+        color="primary"
+        size="large"
+        variant="outlined"
+      >
+        {/* TODO: Extrair a lógica do contador para <DelayedCircularProgress /> */}
+        {loadingMore && tooLong ? <CircularProgress size={22} /> : children}
+      </Button>
+    );
+  }
+}
 
 LoadMoreButton.propTypes = {
   children: PropTypes.node.isRequired,

--- a/frontend/src/components/LoadMoreButton.js
+++ b/frontend/src/components/LoadMoreButton.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, withStyles } from '@material-ui/core';
+
+const styles = theme => ({
+  loadMoreButton: {
+    borderStyle: 'dashed',
+    marginTop: theme.spacing.unit * 2,
+    width: '100%',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    display: 'table',
+  },
+  [theme.breakpoints.up('sm')]: {
+    loadMoreButton: {
+      width: '49%',
+    },
+  },
+  [theme.breakpoints.up('md')]: {
+    loadMoreButton: {
+      maxWidth: '32%',
+    },
+  },
+});
+
+const LoadMoreButton = ({ children, classes, onClick }) => {
+  return (
+    <Button
+      onClick={onClick}
+      className={classes.loadMoreButton}
+      color="primary"
+      size="large"
+      variant="outlined"
+    >
+      {children}
+    </Button>
+  );
+};
+
+LoadMoreButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  classes: PropTypes.object.isRequired,
+  onClick: PropTypes.func,
+};
+
+export default withStyles(styles)(LoadMoreButton);

--- a/frontend/src/components/LoadMoreButton.js
+++ b/frontend/src/components/LoadMoreButton.js
@@ -26,16 +26,28 @@ const styles = theme => ({
   },
 });
 
-const LoadMoreButton = ({ children, classes, loading, onLoadMore, setLoading }) => {
+const LoadMoreButton = ({
+  children,
+  classes,
+  hasMore,
+  loading,
+  onLoadMore,
+  setHasMore,
+  setLoading,
+}) => {
   return (
     <Button
       onClick={async () => {
         setLoading(true);
         // A função fetchMore() do Apollo Client retorna Promise<ApolloQueryResult>
-        await onLoadMore();
+        const result = await onLoadMore();
+        // Isto está acoplado com a questionsConnection.
+        // Este estado deveria ficar no ListConnector, e os valores passados como props:
+        // 'fetchingMore' e 'hasMore'.
+        setHasMore(result.data.questionsConnection.pageInfo.hasNextPage);
         setLoading(false);
       }}
-      disabled={loading}
+      disabled={loading || !hasMore}
       className={classes.loadMoreButton}
       color="primary"
       size="large"
@@ -49,12 +61,15 @@ const LoadMoreButton = ({ children, classes, loading, onLoadMore, setLoading }) 
 LoadMoreButton.propTypes = {
   children: PropTypes.node.isRequired,
   classes: PropTypes.object.isRequired,
+  hasMore: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
   onLoadMore: PropTypes.func,
+  setHasMore: PropTypes.func.isRequired,
   setLoading: PropTypes.func.isRequired,
 };
 
 export default compose(
+  withState('hasMore', 'setHasMore', true),
   withState('loading', 'setLoading', false),
   withStyles(styles),
 )(LoadMoreButton);

--- a/frontend/src/components/Question/CreateConnector.js
+++ b/frontend/src/components/Question/CreateConnector.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo';
-import { allQuestionsQuery } from './ListConnector';
+import { questionsConnection } from './ListConnector';
 
 export const newQuestionMutation = gql`
   mutation newQuestionMutation($input: QuestionCreateInput!) {
@@ -26,10 +26,14 @@ const CreateConnector = ({ children }) => (
     mutation={newQuestionMutation}
     update={(proxy, { data: { createQuestion } }) => {
       try {
-        const data = proxy.readQuery({ query: allQuestionsQuery });
-        data.questions.push(createQuestion.question);
+        const data = proxy.readQuery({ query: questionsConnection });
+        const questionEdge = {
+          cursor: createQuestion.question.id,
+          node: createQuestion.question,
+        };
+        data.questionsConnection.unshift(questionEdge);
 
-        proxy.writeQuery({ query: allQuestionsQuery, data });
+        proxy.writeQuery({ query: questionsConnection, data });
       } catch (error) {
         // Do nothing. Questions were not fetched yet.
       }

--- a/frontend/src/components/Question/CreateConnector.js
+++ b/frontend/src/components/Question/CreateConnector.js
@@ -21,24 +21,24 @@ export const newQuestionMutation = gql`
   }
 `;
 
-const CreateConnector = ({ children }) => (
-  <Mutation
-    mutation={newQuestionMutation}
-    update={(proxy, { data: { createQuestion } }) => {
-      try {
-        const data = proxy.readQuery({ query: questionsConnection });
-        const questionEdge = {
-          cursor: createQuestion.question.id,
-          node: createQuestion.question,
-        };
-        data.questionsConnection.unshift(questionEdge);
+// Atualiza o cache do Apollo com a nova questão
+const updateApolloStore = (proxy, { data: { createQuestion } }) => {
+  try {
+    const data = proxy.readQuery({ query: questionsConnection });
+    const questionEdge = {
+      cursor: createQuestion.question.id,
+      node: createQuestion.question,
+    };
+    data.questionsConnection.unshift(questionEdge);
 
-        proxy.writeQuery({ query: questionsConnection, data });
-      } catch (error) {
-        // Do nothing. Questions were not fetched yet.
-      }
-    }}
-  >
+    proxy.writeQuery({ query: questionsConnection, data });
+  } catch (error) {
+    // Do nothing. Questions were not fetched yet.
+  }
+};
+
+const CreateConnector = ({ children }) => (
+  <Mutation mutation={newQuestionMutation} update={updateApolloStore}>
     {createQuestion => children({ createQuestion })}
   </Mutation>
 );

--- a/frontend/src/components/Question/Details.js
+++ b/frontend/src/components/Question/Details.js
@@ -34,7 +34,7 @@ const QuestionDetails = ({ classes, router }) => {
                 <EditIcon />
               </FAButton>
             </NextLink>
-            <Typography variant="body1" gutterBottom paragraph>
+            <Typography variant="subtitle1" gutterBottom paragraph>
               {question.wording}
             </Typography>
             {question.imageFullUrl && (
@@ -45,7 +45,7 @@ const QuestionDetails = ({ classes, router }) => {
               />
             )}
             {question.secondaryWording && (
-              <Typography component="" variant="body1" gutterBottom paragraph>
+              <Typography variant="subtitle1" gutterBottom paragraph>
                 {question.secondaryWording}
               </Typography>
             )}

--- a/frontend/src/components/Question/DetailsConnector.js
+++ b/frontend/src/components/Question/DetailsConnector.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { Query, Mutation } from 'react-apollo';
-import { allQuestionsQuery } from './ListConnector';
+import { questionsConnection } from './ListConnector';
 
 export const questionQuery = gql`
   query questionQuery($id: ID!) {
@@ -53,10 +53,14 @@ const QuestionDetailsConnector = ({ children, id }) => (
         mutation={updateQuestionMutation}
         update={(proxy, { data: { updateQuestion } }) => {
           try {
-            const cacheData = proxy.readQuery({ query: allQuestionsQuery });
-            cacheData.questions.push(updateQuestion.question);
+            const cacheData = proxy.readQuery({ query: questionsConnection });
+            const questionEdge = {
+              cursor: updateQuestion.question.id,
+              node: updateQuestion.question,
+            };
+            cacheData.questionsConnection.unshift(questionEdge);
 
-            proxy.writeQuery({ query: allQuestionsQuery, cacheData });
+            proxy.writeQuery({ query: questionsConnection, cacheData });
           } catch (cacheError) {
             // Do nothing. Questions were not fetched yet.
           }

--- a/frontend/src/components/Question/DetailsConnector.js
+++ b/frontend/src/components/Question/DetailsConnector.js
@@ -37,6 +37,22 @@ export const updateQuestionMutation = gql`
   }
 `;
 
+// Atualiza o cache do Apollo com as alterações realizadas
+const updateApolloStore = (proxy, { data: { updateQuestion } }) => {
+  try {
+    const cacheData = proxy.readQuery({ query: questionsConnection });
+    const questionEdge = {
+      cursor: updateQuestion.question.id,
+      node: updateQuestion.question,
+    };
+    cacheData.questionsConnection.unshift(questionEdge);
+
+    proxy.writeQuery({ query: questionsConnection, cacheData });
+  } catch (cacheError) {
+    // Do nothing. Questions were not fetched yet.
+  }
+};
+
 // Maybe put this in responseToFormValues()
 const filesHost = 'http://localhost:4000/files';
 export const questionWithFullUrl = question => ({
@@ -49,23 +65,7 @@ export const questionWithFullUrl = question => ({
 const QuestionDetailsConnector = ({ children, id }) => (
   <Query query={questionQuery} variables={{ id }}>
     {({ data, error, loading }) => (
-      <Mutation
-        mutation={updateQuestionMutation}
-        update={(proxy, { data: { updateQuestion } }) => {
-          try {
-            const cacheData = proxy.readQuery({ query: questionsConnection });
-            const questionEdge = {
-              cursor: updateQuestion.question.id,
-              node: updateQuestion.question,
-            };
-            cacheData.questionsConnection.unshift(questionEdge);
-
-            proxy.writeQuery({ query: questionsConnection, cacheData });
-          } catch (cacheError) {
-            // Do nothing. Questions were not fetched yet.
-          }
-        }}
-      >
+      <Mutation mutation={updateQuestionMutation} update={updateApolloStore}>
         {updateQuestion => {
           if (loading) return <h1>Carregando questão...</h1>;
           return children({

--- a/frontend/src/components/Question/List.js
+++ b/frontend/src/components/Question/List.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core';
+import { withStyles, Button } from '@material-ui/core';
 import ListItem from './ListItem';
 import ListConnector from './ListConnector';
 import FAButton from '../FAButton';
@@ -11,9 +11,29 @@ const styles = theme => ({
   grid: {
     display: 'flex',
     flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  },
+  loadMoreButton: {
+    borderStyle: 'dashed',
+    marginTop: theme.spacing.unit * 2,
+    width: '100%',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    display: 'table',
+  },
+  [theme.breakpoints.up('sm')]: {
+    loadMoreButton: {
+      width: '49%',
+    },
+  },
+  [theme.breakpoints.up('md')]: {
+    loadMoreButton: {
+      maxWidth: '32%',
+    },
   },
 });
 
+// eslint-disable-next-line react/prefer-stateless-function
 class QuestionList extends React.Component {
   render() {
     const { classes } = this.props;
@@ -21,16 +41,27 @@ class QuestionList extends React.Component {
     return (
       <React.Fragment>
         <Link href="/admin/questao-criar">
-          <FAButton onClick={this.handleOpenCreateDialog} aria-label="Adicionar questão">
+          <FAButton aria-label="Adicionar questão">
             <AddIcon />
           </FAButton>
         </Link>
         <ListConnector>
-          {({ allQuestions }) => (
-            <div className={classes.grid}>
-              {allQuestions.map(question => (
-                <ListItem key={question.id} question={question} />
-              ))}
+          {({ allQuestions, handleLoadMore }) => (
+            <div>
+              <div className={classes.grid}>
+                {allQuestions.map(question => (
+                  <ListItem key={question.id} question={question} />
+                ))}
+              </div>
+              <Button
+                onClick={handleLoadMore}
+                color="primary"
+                size="large"
+                variant="outlined"
+                className={classes.loadMoreButton}
+              >
+                Carregar mais questões
+              </Button>
             </div>
           )}
         </ListConnector>

--- a/frontend/src/components/Question/List.js
+++ b/frontend/src/components/Question/List.js
@@ -29,14 +29,20 @@ class QuestionList extends React.Component {
           </FAButton>
         </Link>
         <ListConnector>
-          {({ questions, handleLoadMore }) => (
+          {({ questions, handleLoadMore, loadingMore, hasMore }) => (
             <div>
               <div className={classes.grid}>
                 {questions.map(question => (
                   <ListItem key={question.id} question={question} />
                 ))}
               </div>
-              <LoadMoreButton onLoadMore={handleLoadMore}>Carregar mais questões</LoadMoreButton>
+              <LoadMoreButton
+                onLoadMore={handleLoadMore}
+                loadingMore={loadingMore}
+                hasMore={hasMore}
+              >
+                Carregar mais questões
+              </LoadMoreButton>
             </div>
           )}
         </ListConnector>

--- a/frontend/src/components/Question/List.js
+++ b/frontend/src/components/Question/List.js
@@ -1,35 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/core';
 import ListItem from './ListItem';
 import ListConnector from './ListConnector';
 import FAButton from '../FAButton';
 import AddIcon from '@material-ui/icons/Add';
 import Link from 'next/link';
+import LoadMoreButton from '../LoadMoreButton';
 
 const styles = theme => ({
   grid: {
     display: 'flex',
     flexWrap: 'wrap',
     justifyContent: 'space-between',
-  },
-  loadMoreButton: {
-    borderStyle: 'dashed',
-    marginTop: theme.spacing.unit * 2,
-    width: '100%',
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    display: 'table',
-  },
-  [theme.breakpoints.up('sm')]: {
-    loadMoreButton: {
-      width: '49%',
-    },
-  },
-  [theme.breakpoints.up('md')]: {
-    loadMoreButton: {
-      maxWidth: '32%',
-    },
   },
 });
 
@@ -53,15 +36,7 @@ class QuestionList extends React.Component {
                   <ListItem key={question.id} question={question} />
                 ))}
               </div>
-              <Button
-                onClick={handleLoadMore}
-                color="primary"
-                size="large"
-                variant="outlined"
-                className={classes.loadMoreButton}
-              >
-                Carregar mais questões
-              </Button>
+              <LoadMoreButton onClick={handleLoadMore}>Carregar mais questões</LoadMoreButton>
             </div>
           )}
         </ListConnector>

--- a/frontend/src/components/Question/List.js
+++ b/frontend/src/components/Question/List.js
@@ -36,7 +36,7 @@ class QuestionList extends React.Component {
                   <ListItem key={question.id} question={question} />
                 ))}
               </div>
-              <LoadMoreButton onClick={handleLoadMore}>Carregar mais questões</LoadMoreButton>
+              <LoadMoreButton onLoadMore={handleLoadMore}>Carregar mais questões</LoadMoreButton>
             </div>
           )}
         </ListConnector>

--- a/frontend/src/components/Question/List.js
+++ b/frontend/src/components/Question/List.js
@@ -29,7 +29,7 @@ class QuestionList extends React.Component {
           </FAButton>
         </Link>
         <ListConnector>
-          {({ questions, handleLoadMore, loadingMore, hasMore }) => (
+          {({ questions, loadMoreHandler, loadingMore, hasMore }) => (
             <div>
               <div className={classes.grid}>
                 {questions.map(question => (
@@ -37,7 +37,7 @@ class QuestionList extends React.Component {
                 ))}
               </div>
               <LoadMoreButton
-                onLoadMore={handleLoadMore}
+                onLoadMore={loadMoreHandler}
                 loadingMore={loadingMore}
                 hasMore={hasMore}
               >

--- a/frontend/src/components/Question/List.js
+++ b/frontend/src/components/Question/List.js
@@ -46,10 +46,10 @@ class QuestionList extends React.Component {
           </FAButton>
         </Link>
         <ListConnector>
-          {({ allQuestions, handleLoadMore }) => (
+          {({ questions, handleLoadMore }) => (
             <div>
               <div className={classes.grid}>
-                {allQuestions.map(question => (
+                {questions.map(question => (
                   <ListItem key={question.id} question={question} />
                 ))}
               </div>

--- a/frontend/src/components/Question/ListConnector.js
+++ b/frontend/src/components/Question/ListConnector.js
@@ -64,6 +64,7 @@ const ListConnector = ({ children }) => (
           ),
         ),
         handleLoadMore: () =>
+          // fetchMore(fetchMoreOptions): Promise<ApolloQueryResult>
           fetchMore({
             variables: {
               cursor: data.questionsConnection.pageInfo.endCursor,

--- a/frontend/src/components/Question/ListConnector.js
+++ b/frontend/src/components/Question/ListConnector.js
@@ -63,7 +63,7 @@ const ListConnector = ({ children, hasMore, loadingMore, setHasMore, setLoadingM
           questionEdgeToNode,
         ),
       );
-      const handleLoadMore = async () => {
+      const loadMoreHandler = async () => {
         setLoadingMore(true);
         // A função fetchMore() do Apollo Client retorna Promise<ApolloQueryResult>
         const result = await fetchMore({
@@ -82,7 +82,7 @@ const ListConnector = ({ children, hasMore, loadingMore, setHasMore, setLoadingM
         questions,
         loadingMore,
         hasMore,
-        handleLoadMore,
+        loadMoreHandler,
       });
     }}
   </Query>

--- a/frontend/src/components/Question/ListConnector.js
+++ b/frontend/src/components/Question/ListConnector.js
@@ -56,29 +56,33 @@ const ListConnector = ({ children, hasMore, loadingMore, setHasMore, setLoadingM
     {({ data, error, fetchMore, loading }) => {
       if (loading) return <p>Carregando questões...</p>;
       if (error) return <p>{`Erro ao carregar questões: ${error}`}</p>;
+
+      const questions = data.questionsConnection.edges.map(
+        compose(
+          questionWithFullUrl,
+          questionEdgeToNode,
+        ),
+      );
+      const handleLoadMore = async () => {
+        setLoadingMore(true);
+        // A função fetchMore() do Apollo Client retorna Promise<ApolloQueryResult>
+        const result = await fetchMore({
+          variables: {
+            cursor: data.questionsConnection.pageInfo.endCursor,
+          },
+          updateQuery,
+        });
+        setHasMore(result.data.questionsConnection.pageInfo.hasNextPage);
+        setLoadingMore(false);
+        return result;
+      };
+
       return children({
         // Move this logic to responseToFormValues() maybe?
-        questions: data.questionsConnection.edges.map(
-          compose(
-            questionWithFullUrl,
-            questionEdgeToNode,
-          ),
-        ),
+        questions,
         loadingMore,
         hasMore,
-        handleLoadMore: async () => {
-          setLoadingMore(true);
-          // A função fetchMore() do Apollo Client retorna Promise<ApolloQueryResult>
-          const result = await fetchMore({
-            variables: {
-              cursor: data.questionsConnection.pageInfo.endCursor,
-            },
-            updateQuery,
-          });
-          setHasMore(result.data.questionsConnection.pageInfo.hasNextPage);
-          setLoadingMore(false);
-          return result;
-        },
+        handleLoadMore,
       });
     }}
   </Query>

--- a/frontend/src/components/Question/ListConnector.js
+++ b/frontend/src/components/Question/ListConnector.js
@@ -57,7 +57,7 @@ const ListConnector = ({ children }) => (
       if (error) return <p>{`Erro ao carregar questões: ${error}`}</p>;
       return children({
         // Move this logic to responseToFormValues() maybe?
-        allQuestions: data.questionsConnection.edges.map(
+        questions: data.questionsConnection.edges.map(
           compose(
             questionWithFullUrl,
             questionEdgeToNode,

--- a/frontend/src/components/Question/ListConnector.js
+++ b/frontend/src/components/Question/ListConnector.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
-import { Query } from 'react-apollo';
+import { Query, compose } from 'react-apollo';
 import { questionWithFullUrl } from './DetailsConnector';
 
 export const allQuestionsQuery = gql`
@@ -19,14 +19,74 @@ export const allQuestionsQuery = gql`
   }
 `;
 
+// TODO: Preciso arrumar createConnector e DetailConnector pra atualizar
+// o cache com essa Query agora.
+export const questionsConnection = gql`
+  query questionsConnection($cursor: String) {
+    questionsConnection(first: 6, after: $cursor) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      edges {
+        node {
+          id
+          type
+          wording
+          imageUrl
+          choices {
+            id
+            text
+          }
+        }
+        cursor
+      }
+    }
+  }
+`;
+
+const updateQuery = (previousResult, { fetchMoreResult }) => {
+  const newEdges = fetchMoreResult.questionsConnection.edges;
+  const pageInfo = fetchMoreResult.questionsConnection.pageInfo;
+
+  return newEdges.length
+    ? {
+        // Put the new questions at the end of the list and update `pageInfo`
+        // so we have the new `endCursor` and `hasNextPage` values
+        questionsConnection: {
+          // eslint-disable-next-line no-underscore-dangle
+          __typename: previousResult.questionsConnection.__typename,
+          edges: [...previousResult.questionsConnection.edges, ...newEdges],
+          pageInfo,
+        },
+      }
+    : previousResult;
+};
+
+const questionEdgeToNode = questionEdge => questionEdge.node;
+
 const ListConnector = ({ children }) => (
-  <Query query={allQuestionsQuery}>
-    {({ data, error, loading }) => {
+  <Query query={questionsConnection}>
+    {({ data, error, fetchMore, loading }) => {
       if (loading) return <p>Carregando questões...</p>;
       if (error) return <p>{`Erro ao carregar questões: ${error}`}</p>;
       return children({
         // Move this logic to responseToFormValues() maybe?
-        allQuestions: data.questions.map(questionWithFullUrl),
+        allQuestions: data.questionsConnection.edges.map(
+          compose(
+            questionWithFullUrl,
+            questionEdgeToNode,
+          ),
+        ),
+        handleLoadMore: () =>
+          fetchMore({
+            variables: {
+              cursor: data.questionsConnection.pageInfo.endCursor,
+            },
+            updateQuery,
+          }),
       });
     }}
   </Query>

--- a/frontend/src/components/Question/ListConnector.js
+++ b/frontend/src/components/Question/ListConnector.js
@@ -4,26 +4,9 @@ import gql from 'graphql-tag';
 import { Query, compose } from 'react-apollo';
 import { questionWithFullUrl } from './DetailsConnector';
 
-export const allQuestionsQuery = gql`
-  query allQuestionsQuery {
-    questions {
-      id
-      type
-      wording
-      imageUrl
-      choices {
-        id
-        text
-      }
-    }
-  }
-`;
-
-// TODO: Preciso arrumar createConnector e DetailConnector pra atualizar
-// o cache com essa Query agora.
 export const questionsConnection = gql`
   query questionsConnection($cursor: String) {
-    questionsConnection(first: 6, after: $cursor) {
+    questionsConnection(first: 6, after: $cursor, orderBy: createdAt_DESC) {
       pageInfo {
         hasNextPage
         hasPreviousPage

--- a/frontend/src/components/Question/ListItem.js
+++ b/frontend/src/components/Question/ListItem.js
@@ -16,10 +16,19 @@ import ChoicesBox from './ChoicesBox';
 
 const styles = theme => ({
   card: {
-    maxWidth: 265,
+    maxWidth: '100%',
     maxHeight: 300,
-    marginRight: theme.spacing.unit * 2,
     marginTop: theme.spacing.unit * 2,
+  },
+  [theme.breakpoints.up('sm')]: {
+    card: {
+      maxWidth: '49%',
+    },
+  },
+  [theme.breakpoints.up('md')]: {
+    card: {
+      maxWidth: '32%',
+    },
   },
   iconButton: {
     padding: 8,
@@ -50,7 +59,9 @@ const ListItem = props => {
               question.choices &&
               question.choices.length > 0 && <ChoicesBox choices={question.choices} dense />}
           </CardContent>
-          {question.imageFullUrl && <CardMedia className={classes.media} image={question.imageFullUrl} />}
+          {question.imageFullUrl && (
+            <CardMedia className={classes.media} image={question.imageFullUrl} />
+          )}
         </CardActionArea>
       </NextLink>
       <CardActions>

--- a/frontend/src/utils/withRoot.js
+++ b/frontend/src/utils/withRoot.js
@@ -106,14 +106,17 @@ const pages = [
       {
         pathname: '/admin/questao-criar',
         title: 'Criar Questão',
+        displayNav: false,
       },
       {
         pathname: '/admin/questao-editar',
         title: 'Editar Questão',
+        displayNav: false,
       },
       {
         pathname: '/admin/questao',
         title: 'Detalhes da Questão',
+        displayNav: false,
       },
       {
         pathname: '/admin/questoes',


### PR DESCRIPTION
No _frontend_ implementei um botão de "Carregar mais questões". Também adicionei um [atraso pra mostrar a animação "carregando"](https://material-ui.com/demos/progress/#delaying-appearance), pra ela não aparecer caso os dados cheguem em menos de _800ms_. O usuário só precisa de _feedback_ se ele achar que a aplicação não está operando apropriadamente, caso contrário nem mostramos a animação. Em menos de _800ms_ a animação só vai piscar, não vale a pena.

No futuro isso pode ser aprimorado com a implementação do _Lazy loading_ combinado com "Carregar mais":

> For category navigation, use a combination of the “Load more” button and lazy-loading. Set the threshold for the “Load more” button to 50 to 100 items --- [Infinite Scrolling, P agination Or “Load More” Buttons? Usability Findings In eCommerce](https://www.smashingmagazine.com/2016/03/pagination-infinite-scrolling-load-more-buttons/).

No _backend_ a implementação foi feita com o modelo de paginação do Relay, que utiliza [_cursor connections_](https://facebook.github.io/relay/graphql/connections.htm). Apesar do [modelo parecer complexo](https://graphql.org/learn/pagination/#complete-connection-model), a implementação foi trivial, pois o *Prisma* oferece os [Conneciton queries](https://www.prisma.io/docs/prisma-graphql-api/reference/queries-qwe1/#connection-queries). Confira o primeiro commit: [_Add questionsConnection to GraphQL schema_](https://github.com/iquabius/olimat/pull/23/commits/b330a9b728a9f53bfe73c817654474e3f55ef3a0).