### PR TITLE
Set up Codecov orb in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 orbs:
+  codecov: codecov/codecov@1.0.3
   cypress: cypress-io/cypress@1.5.0
 
 executors:
@@ -81,9 +82,8 @@ jobs:
           name: Testing
           command: npm run test:coverage
 
-      - run:
-          name: Upload test coverage reports to Codecov
-          command: npm run test:coverage:upload
+      # Upload test coverage reports to Codecov
+      - codecov/upload
 
 workflows:
   version: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1398,12 +1398,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
-      "dev": true
-    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2149,19 +2143,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
-    },
-    "codecov": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.1.0.tgz",
-      "integrity": "sha512-aWQc/rtHbcWEQLka6WmBAOpV58J2TwyXqlpAQGhQaSiEUoigTTUk6lLd2vB3kXkhnDyzyH74RXfmV4dq2txmdA==",
-      "dev": true,
-      "requires": {
-        "argv": "^0.0.2",
-        "ignore-walk": "^3.0.1",
-        "js-yaml": "^3.12.0",
-        "request": "^2.87.0",
-        "urlgrey": "^0.4.4"
-      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -9822,12 +9803,6 @@
           "dev": true
         }
       }
-    },
-    "urlgrey": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
-      "dev": true
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "lint:check": "tslint-config-prettier-check ./tslint.json ./api/tslint.json ./web/tslint.json",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:coverage:upload": "codecov",
     "test:codecov:validate": "curl --data-binary @codecov.yml https://codecov.io/validate",
     "test:watch": "jest --watch",
     "typecheck": "npm-run-all --parallel typecheck:*",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@types/react-jss": "8.6.0",
     "@types/recompose": "0.30.3",
     "@types/yup": "0.26.6",
-    "codecov": "3.1.0",
     "cypress": "3.1.4",
     "cypress-testing-library": "2.3.5",
     "faker": "4.1.0",


### PR DESCRIPTION
Use the [CircleCI orb for Codecov](https://circleci.com/orbs/registry/orb/codecov/codecov) to upload reports in the CI pipeline.

As resources, I used this webinar ["Codecov and CircleCI Orbs: Making Code Coverage Easy"](https://youtu.be/gyNeEOEhME0) and [the example project](https://github.com/codecov/example-circleci-orb).

Closes #52 