### PR TITLE
Fix Jest out of memory running in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint:check:api": "eslint --print-config 'packages/api/**/*' | eslint-config-prettier-check",
     "lint:check:web": "eslint --print-config 'packages/web/**/*' | eslint-config-prettier-check",
     "test": "jest",
-    "test:coverage": "jest --coverage",
+    "test:coverage": "jest --ci --coverage --runInBand",
     "test:codecov:validate": "curl --data-binary @codecov.yml https://codecov.io/validate",
     "test:watch": "jest --watch",
     "typecheck": "npm-run-all --parallel typecheck:*",


### PR DESCRIPTION
"When running Jest tests, please use the --runInBand flag.
Without this flag, Jest will try to allocate the CPU resources
of the entire virtual machine in which your job is running."

https://circleci.com/docs/2.0/collect-test-data/#jest