### PR TITLE
Ativa teste da busca de detalhes da cidade

### DIFF
--- a/packages/api/src/__tests__/__snapshots__/integration.ts.snap
+++ b/packages/api/src/__tests__/__snapshots__/integration.ts.snap
@@ -27,3 +27,21 @@ Object {
   },
 }
 `;
+
+exports[`Queries fetches single city 1`] = `
+Object {
+  "data": Object {
+    "city": Object {
+      "id": "cId1",
+      "name": "Barra do Bugres",
+    },
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;

--- a/packages/api/src/__tests__/integration.ts
+++ b/packages/api/src/__tests__/integration.ts
@@ -14,14 +14,14 @@ const getCitiesQuery = gql`
   }
 `;
 
-// const getCityQuery = gql`
-//   query getCity($id: ID!) {
-//     city(id: $id) {
-//       id
-//       name
-//     }
-//   }
-// `;
+const getCityQuery = gql`
+  query getCity($id: ID!) {
+    city(id: $id) {
+      id
+      name
+    }
+  }
+`;
 
 describe('Queries', () => {
   beforeAll(() => nock.disableNetConnect());
@@ -60,25 +60,25 @@ describe('Queries', () => {
   });
 
   // 'query', de createTestServer(), está com o tipo errado, parece um bug.
-  // xtest('fetches single city', async () => {
-  //   const mockCity = { id: 'cId1', name: 'Barra do Bugres' };
+  test('fetches single city', async () => {
+    const mockCity = { id: 'cId1', name: 'Barra do Bugres' };
 
-  //   // nock.recorder.rec();
-  //   nock('http://localhost:4466')
-  //     .post('/olimat-api/dev')
-  //     .reply(200, [
-  //       {
-  //         data: {
-  //           city: mockCity,
-  //         },
-  //       },
-  //     ]);
+    // nock.recorder.rec();
+    nock('http://localhost:4466')
+      .post('/olimat-api/dev')
+      .reply(200, [
+        {
+          data: {
+            city: mockCity,
+          },
+        },
+      ]);
 
-  //   const server = createTestServer();
+    const server = createTestServer();
 
-  //   const { query } = createTestClient(server);
-  //   const res = await query({ query: getCityQuery, variables: { id: mockCity.id } });
-  //   expect(res).toMatchSnapshot();
-  //   expect(res).toBe(mockCity);
-  // });
+    const { query } = createTestClient(server);
+    const res = await query({ query: getCityQuery, variables: { id: mockCity.id } });
+    expect(res).toMatchSnapshot();
+    expect(res.data.city).toEqual(mockCity);
+  });
 });


### PR DESCRIPTION
Eu tinha desativado porque havia algum problema com os tipos do `createTestServer()` relacionado as `variables` da consulta.