### PR TITLE
Update dependency graphql to v14.6.0

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -4783,9 +4783,9 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "graphql": {
-      "version": "14.4.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz",
-      "integrity": "sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==",
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
+      "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
       "requires": {
         "iterall": "^1.2.2"
       }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,7 @@
     "filepond-plugin-image-exif-orientation": "1.0.4",
     "filepond-plugin-image-preview": "3.1.6",
     "formik": "1.5.8",
-    "graphql": "14.4.2",
+    "graphql": "^14.6.0",
     "isomorphic-unfetch": "3.0.0",
     "jss": "10.0.4",
     "lodash": "4.17.15",

--- a/packages/web/src/components/Question/Details.test.tsx
+++ b/packages/web/src/components/Question/Details.test.tsx
@@ -2,6 +2,7 @@ import Router from 'next/router';
 import { SnackbarProvider } from 'notistack';
 import React from 'react';
 import { fireEvent, render, waitForElement } from 'react-testing-library';
+import { GraphQLError } from 'graphql';
 
 import FakeDataProvider from '@olimat/web/utils/test/FakeDataProvider';
 import MockErrorProvider from '@olimat/web/utils/test/MockErrorProvider';
@@ -144,7 +145,9 @@ describe('<QuestionDetails />', () => {
 					query: deleteQuestionMutation,
 					variables: { id: data.question.id },
 				},
-				result: { errors: [{ message: errorMsg }] },
+				// This simulates a GraphQL error:
+				// https://www.apollographql.com/docs/react/development-testing/testing/#testing-error-states
+				result: { errors: [new GraphQLError(errorMsg)] },
 			},
 		];
 

--- a/packages/web/src/utils/test/mockGraphql.ts
+++ b/packages/web/src/utils/test/mockGraphql.ts
@@ -14,7 +14,8 @@ const mockGraphql = async (query, args = {}) => {
 		const res = await graphql(schema, query.loc.source.body, null, null, args);
 		return res.data;
 	} catch (e) {
-		return console.log(e.message);
+		console.log(e.message);
+		return { errors: e };
 	}
 };
 


### PR DESCRIPTION
We'll wait for Apollo Client 3.0 be stable before updating graphql to version 15:

https://github.com/apollographql/graphql-tag/issues/298