### PR TITLE
Refactor Link to use @material-ui/core/Link

### DIFF
--- a/packages/web/src/components/AppDrawer.tsx
+++ b/packages/web/src/components/AppDrawer.tsx
@@ -10,7 +10,6 @@ import {
 } from '@material-ui/core/styles';
 import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 import Toolbar from '@material-ui/core/Toolbar';
-import Typography from '@material-ui/core/Typography';
 import clsx from 'clsx';
 import React, { ReactEventHandler } from 'react';
 
@@ -45,9 +44,6 @@ const styles = ({ palette }: Theme) =>
 			flexDirection: 'column',
 			alignItems: 'center',
 			justifyContent: 'center',
-		},
-		anchor: {
-			color: palette.text.secondary,
 		},
 	});
 
@@ -139,10 +135,14 @@ const AppDrawer: React.FunctionComponent<Props> = props => {
 				<React.Fragment>
 					<div className={classes.toolbarIe11}>
 						<Toolbar className={classes.toolbar}>
-							<Link className={classes.title} href="/" onClick={onClose}>
-								<Typography variant="h3" color="inherit">
-									OliMAT
-								</Typography>
+							<Link
+								className={classes.title}
+								href="/"
+								onClick={onClose}
+								variant="h3"
+								color="inherit"
+							>
+								OliMAT
 							</Link>
 							<Divider absolute />
 						</Toolbar>

--- a/packages/web/src/components/AppDrawerNavItem.tsx
+++ b/packages/web/src/components/AppDrawerNavItem.tsx
@@ -109,7 +109,7 @@ class AppDrawerNavItem extends React.Component<Props, State> {
 					<Button
 						component={props => (
 							<Link
-								variant="button"
+								naked
 								activeClassName={classes.active}
 								href={href}
 								{...props}

--- a/packages/web/src/components/AppFooter.tsx
+++ b/packages/web/src/components/AppFooter.tsx
@@ -38,15 +38,23 @@ const AppFooter = props => {
 						<Grid item xs={12} sm={6}>
 							<ul className={classes.list}>
 								<li className={classes.listItem}>
-									<Link href="https://github.com/mui-org/material-ui">
+									<Link
+										color="inherit"
+										href="https://github.com/mui-org/material-ui"
+									>
 										GitHub
 									</Link>
 								</li>
 								<li className={classes.listItem}>
-									<Link href="https://twitter.com/MaterialUI">Twitter</Link>
+									<Link color="inherit" href="https://twitter.com/MaterialUI">
+										Twitter
+									</Link>
 								</li>
 								<li className={classes.listItem}>
-									<Link href="https://github.com/mui-org/material-ui/tree/v1-beta/examples">
+									<Link
+										color="inherit"
+										href="https://github.com/mui-org/material-ui/tree/v1-beta/examples"
+									>
 										Examples
 									</Link>
 								</li>
@@ -55,13 +63,19 @@ const AppFooter = props => {
 						<Grid item xs={12} sm={6}>
 							<ul className={classes.list}>
 								<li className={classes.listItem}>
-									<Link href="/discover-more/community">Community</Link>
+									<Link color="inherit" href="/discover-more/community">
+										Community
+									</Link>
 								</li>
 								<li className={classes.listItem}>
-									<Link href="/discover-more/roadmap">Roadmap</Link>
+									<Link color="inherit" href="/discover-more/roadmap">
+										Roadmap
+									</Link>
 								</li>
 								<li className={classes.listItem}>
-									<Link href="/discover-more/team">Team</Link>
+									<Link color="inherit" href="/discover-more/team">
+										Team
+									</Link>
 								</li>
 							</ul>
 						</Grid>

--- a/packages/web/src/components/Link.tsx
+++ b/packages/web/src/components/Link.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import * as React from 'react';
 import clsx from 'clsx';
 import { useRouter } from 'next/router';

--- a/packages/web/src/components/Link.tsx
+++ b/packages/web/src/components/Link.tsx
@@ -18,6 +18,7 @@ const NextComposed = React.forwardRef<HTMLAnchorElement, NextComposedProps>(
 		const {
 			as,
 			href,
+			children,
 			replace,
 			scroll,
 			passHref,
@@ -36,7 +37,9 @@ const NextComposed = React.forwardRef<HTMLAnchorElement, NextComposedProps>(
 				shallow={shallow}
 				passHref={passHref}
 			>
-				<a ref={ref} {...other} />
+				<a ref={ref} {...other}>
+					{children}
+				</a>
 			</NextLink>
 		);
 	},

--- a/packages/web/src/components/User/LoginForm.tsx
+++ b/packages/web/src/components/User/LoginForm.tsx
@@ -160,7 +160,7 @@ const LoginForm: React.FC<Props> = props => {
 				align="center"
 			>
 				Ainda não tem uma conta?{' '}
-				<Link variant="primary" href="/criar_conta">
+				<Link color="primary" href="/criar_conta">
 					Crie a sua aqui.
 				</Link>
 			</Typography>

--- a/packages/web/src/components/User/SignUpForm.tsx
+++ b/packages/web/src/components/User/SignUpForm.tsx
@@ -183,7 +183,7 @@ const SignUpForm: React.FC<Props> = props => {
 				align="center"
 			>
 				Já possui uma conta?{' '}
-				<Link variant="primary" href="/login">
+				<Link color="primary" href="/login">
 					Faça login aqui.
 				</Link>
 			</Typography>

--- a/packages/web/src/components/UserMenuAppBar.tsx
+++ b/packages/web/src/components/UserMenuAppBar.tsx
@@ -78,7 +78,7 @@ const UserMenuAppBar: React.FC = props => {
 					<Button
 						color="inherit"
 						component={buttonProps => (
-							<Link variant="button" href="/login" {...buttonProps} />
+							<Link naked href="/login" {...buttonProps} />
 						)}
 					>
 						Login

--- a/packages/web/src/pages/index.tsx
+++ b/packages/web/src/pages/index.tsx
@@ -103,7 +103,7 @@ const PageHome = props => {
 							<Button
 								component={buttonProps => (
 									<Link
-										variant="button"
+										naked
 										href="/getting-started/installation"
 										{...buttonProps}
 									/>


### PR DESCRIPTION
Material-UI has [a new Link component](https://material-ui.com/components/links) that can be used to create a styled version of Next.js' Link.

This is based on mui-org/material-ui#14093 with some differences because Next.js was still in version 8 there.