### PR TITLE
Remove graphql-import from web package

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -4752,24 +4752,6 @@
         "iterall": "^1.2.2"
       }
     },
-    "graphql-import": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.7.1.tgz",
-      "integrity": "sha512-YpwpaPjRUVlw2SN3OPljpWbVRWAhMAyfSba5U47qGMOSsPLi2gYeJtngGpymjm9nk57RFWEpjqwh4+dpYuFAPw==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.4",
-        "resolve-from": "^4.0.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-          "dev": true
-        }
-      }
-    },
     "graphql-tag": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.3.tgz",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -55,7 +55,6 @@
     "@types/yup": "0.29.3",
     "cross-env": "7.0.2",
     "faker": "4.1.0",
-    "graphql-import": "0.7.1",
     "graphql-tools": "4.0.8",
     "jest-dom": "3.5.0",
     "react-testing-library": "6.1.2",


### PR DESCRIPTION
This dependency is only needed for the api.