### PR TITLE
Upgrade cypress/base image to v14.0.0 in CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   prisma:
     docker:
-      - image: cypress/base:10
+      - image: cypress/base:14.0.0
       - image: postgres:10.13
         environment:
           POSTGRES_USER: prisma


### PR DESCRIPTION
For some reason v10 is not working with global functions from Jest 26: #333.
 
```bash
FAIL   API  packages/api/src/__tests__/e2e.ts
 
  ● Test suite failed to run

    ReferenceError: describe is not defined
 
      48 | }
      49 | 
    > 50 | describe('API - e2e', () => {
         | ^
      51 | 	let stop;
      52 | 	let graphql;
      53 | 

      at Object.<anonymous> (src/__tests__/e2e.ts:50:1)
```